### PR TITLE
[T-4718][14.0][IMP] ecommerce_connector: buscar VAT codigo pais, no duplicar nombre direccion facturacion, usar sec odoo en pedidos, asignar carrier a pedido

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Available addons
 ----------------
 addon | version | summary
 --- | --- | ---
-[ecommerce_connector](ecommerce_connector/) | 14.0.2.0.0 | Ecommerce connector base
+[ecommerce_connector](ecommerce_connector/) | 14.0.3.0.0 | Ecommerce connector base
 [product_management_connector](product_management_connector/) | 14.0.1.0.0 | Create/Edit product connectors
 [stock_check_connector](stock_check_connector/) | 14.0.1.0.0 | Get products stock informations
 

--- a/ecommerce_connector/README.rst
+++ b/ecommerce_connector/README.rst
@@ -1,0 +1,68 @@
+.. image:: https://img.shields.io/badge/licence-AGPL--3-blue.svg
+	:target: http://www.gnu.org/licenses/agpl
+	:alt: License: AGPL-3
+
+====================
+E-Commerce Connector
+====================
+
+This module is a general e-commerce connector which can be used to integrate any
+e-commerce with Odoo. It allows to import sale orders from an external e-commerce into
+Odoo, invoice those sales and create contacts and products if needed.
+
+
+Installation
+============
+
+Check the operations manual provided by Sygel.
+
+
+Configuration
+=============
+
+Check the operations manual provided by Sygel.
+
+
+Usage
+=====
+
+Check the operations manual provided by Sygel.
+
+
+Bug Tracker
+===========
+
+Bugs and errors are managed in `issues of GitHub <https://github.com/sygel-technology/sy-general-connector/issues>`_.
+In case of problems, please check if your problem has already been
+reported. If you are the first to discover it, help us solving it by indicating
+a detailed description `here <https://github.com/sygel-technology/sy-general-connector/issues/new>`_.
+
+Do not contact contributors directly about support or help with technical issues.
+
+
+Credits
+=======
+
+Authors
+~~~~~~~
+
+* Sygel, Odoo Community Association (OCA)
+
+Contributors
+~~~~~~~~~~~~
+
+* Manuel Regidor <manuel.regidor@sygel.es>
+* Valentín Vinagre <valentin.vinagre@sygel.es>
+
+Maintainer
+~~~~~~~~~~
+
+This module is maintained by Sygel.
+
+.. image:: https://www.sygel.es/logo.png
+   :alt: Sygel
+   :target: https://www.sygel.es
+
+This module is part of the `Sygel/sy-general-connector <https://github.com/sygel-technology/sy-general-connector>`_.
+
+To contribute to this module, please visit https://github.com/sygel-technology.

--- a/ecommerce_connector/__manifest__.py
+++ b/ecommerce_connector/__manifest__.py
@@ -3,9 +3,9 @@
 
 {
     "name": "Ecommerce Connector",
-    "summary": "Ecommerce Connector",
-    "version": "14.0.2.0.1",
-    "category": "Custom",
+    "summary": "General E-Commerce Integration",
+    "version": "14.0.3.0.0",
+    "category": "Ecommerce",
     "author": "Sygel",
     "license": "AGPL-3",
     "application": False,
@@ -17,7 +17,6 @@
         "account_payment_sale",
         "base_vat",
         "account_fiscal_position_partner_type",
-        # "l10n_es_aeat_sii_oca",
         "product",
         "delivery",
     ],

--- a/ecommerce_connector/models/ecommerce_connection.py
+++ b/ecommerce_connector/models/ecommerce_connection.py
@@ -35,6 +35,15 @@ class EcommerceConnection(models.Model):
         required=True,
         help="Language used for writing operation in multilanguage fields."
     )
+    use_odoo_so_sequence = fields.Boolean(
+        string="Use Odoo Sales Seq."
+    )
+    duplicate_invoice_name = fields.Boolean(
+        string="Duplicate Name in Invoice Address",
+        help="If checked, the Invoice Address name is set in case it equals "
+        "the customer name. If unchecked, the Invoice Address name is left"
+        "blank when it equals the Customer name."
+    )
     product_search_rule = fields.Selection([
         ("ecommerce_id", "Ecommerce ID"),
         ("sku", "SKU"),

--- a/ecommerce_connector/views/ecommerce_connection_views.xml
+++ b/ecommerce_connector/views/ecommerce_connection_views.xml
@@ -22,6 +22,8 @@
                             <group>
                                 <field name="company_id"/>
                                 <field name="lang"/>
+                                <field name="use_odoo_so_sequence"/>
+                                <field name="duplicate_invoice_name"/>
                             </group>
                     </group>
                     <group>


### PR DESCRIPTION
Nuevas funcionalidades:
- Si la búsqueda del cliente se realiza por VAT, este se busca con y sin código del país.
- Se da la opción de si el nombre de la dirección de facturación iguala al nombre del cliente, el nombre de la dirección de facturación se deja en blanco. De esta manera, en los PDF no aparece la fórmula en el cliente ({nombre contacto padre}, nombre contacto facturación). Esto es configurable.
- Se da la opción de utilizar la secuencia de Odoo para el pedido de venta en lugar del número del pedido que llega a través del conector. En ese caso, el nombre del pedido de woocommerce, se pone en el campo "Ref. Cliente" del pedido de venta.
- Se vincula un carrier al pedido de venta.

T-4718