### PR TITLE
[T-8669][15.0][IMP] ecommerce_connector: replace float_compare by float_is_zero

### DIFF
--- a/ecommerce_connector/models/ecommerce_connector.py
+++ b/ecommerce_connector/models/ecommerce_connector.py
@@ -6,7 +6,7 @@ from base64 import b64encode
 from datetime import datetime
 
 from odoo import api, fields, models
-from odoo.tools import float_compare
+from odoo.tools import float_is_zero
 
 
 class EcommerceConnector(models.Model):
@@ -1193,13 +1193,9 @@ class EcommerceConnector(models.Model):
         :param move: account.move record with the newly created invoice
         :param errors: string with the current errors
         """
-        if (
-            float_compare(
-                float(values.get("total")),
-                move.amount_total,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("total")) - move.amount_total,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
@@ -1208,13 +1204,9 @@ class EcommerceConnector(models.Model):
                     move.amount_total, values.get("total")
                 ),
             )
-        if (
-            float_compare(
-                float(values.get("totalCompany")),
-                move.amount_total_signed,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("totalCompany")) - move.amount_total_signed,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
@@ -1223,26 +1215,18 @@ class EcommerceConnector(models.Model):
                     move.amount_total_signed, values.get("totalCompany")
                 ),
             )
-        if (
-            float_compare(
-                float(values.get("taxTotal")),
-                move.amount_tax,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("taxTotal")) - move.amount_tax,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
                 "Tax amount in sales currency ({}) does not match the value sent "
                 "with the call ({}).".format(move.amount_tax, values.get("taxTotal")),
             )
-        if (
-            float_compare(
-                float(values.get("taxTotalCompany")),
-                move.amount_tax_signed,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("taxTotalCompany")) - move.amount_tax_signed,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
@@ -1274,12 +1258,10 @@ class EcommerceConnector(models.Model):
                     " Found {} lines".format(line.get("id"), len(invoice_line)),
                 )
             if not error and (
-                float_compare(
-                    float(line.get("total")),
-                    invoice_line.price_total,
+                not float_is_zero(
+                    float(line.get("total")) - invoice_line.price_total,
                     precision_digits=ecommerce_connection_id.precision_digits,
                 )
-                != 0
             ):
                 errors = self._write_errors(
                     errors,
@@ -1289,12 +1271,10 @@ class EcommerceConnector(models.Model):
                     ),
                 )
             if not error and (
-                float_compare(
-                    float(line.get("subtotal")),
-                    invoice_line.price_subtotal,
+                not float_is_zero(
+                    float(line.get("subtotal")) - invoice_line.price_subtotal,
                     precision_digits=ecommerce_connection_id.precision_digits,
                 )
-                != 0
             ):
                 errors = self._write_errors(
                     errors,
@@ -1329,13 +1309,9 @@ class EcommerceConnector(models.Model):
                 else:
                     compare_val = shipping_line.price_subtotal
                     compare_field = "Subtotal"
-                if (
-                    float_compare(
-                        float(line.get("unitPrice")),
-                        compare_val,
-                        precision_digits=ecommerce_connection_id.precision_digits,
-                    )
-                    != 0
+                if not float_is_zero(
+                    float(line.get("unitPrice")) - compare_val,
+                    precision_digits=ecommerce_connection_id.precision_digits,
                 ):
                     errors = self._write_errors(
                         errors,
@@ -1374,14 +1350,9 @@ class EcommerceConnector(models.Model):
                         errors,
                         "Payment with ID %s could not be found." % payment.get("id"),
                     )
-                elif (
-                    payment_id
-                    and float_compare(
-                        float(payment_id.amount_signed),
-                        float(payment.get("unitPrice")),
-                        precision_digits=ecommerce_connection_id.precision_digits,
-                    )
-                    != 0
+                elif payment_id and not float_is_zero(
+                    float(payment_id.amount_signed) - float(payment.get("unitPrice")),
+                    precision_digits=ecommerce_connection_id.precision_digits,
                 ):
                     errors = self._write_errors(
                         errors,
@@ -1485,13 +1456,9 @@ class EcommerceConnector(models.Model):
                 shipping_line = move.invoice_line_ids.filtered(
                     lambda a, line=line: a.ecommerce_shipping_id == int(line.get("id"))
                 )
-                if (
-                    float_compare(
-                        float(line.get("unitPrice")),
-                        shipping_line.price_subtotal,
-                        precision_digits=ecommerce_connection_id.precision_digits,
-                    )
-                    != 0
+                if not float_is_zero(
+                    float(line.get("unitPrice")) - shipping_line.price_subtotal,
+                    precision_digits=ecommerce_connection_id.precision_digits,
                 ):
                     errors = self._write_errors(
                         errors,
@@ -1512,13 +1479,9 @@ class EcommerceConnector(models.Model):
         :param move: sale.order record with the newly created invoice
         :param errors: string with the current errors
         """
-        if (
-            float_compare(
-                float(values.get("total")),
-                order.amount_total,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("total")) - order.amount_total,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
@@ -1528,13 +1491,9 @@ class EcommerceConnector(models.Model):
                     values.get("total"),
                 ),
             )
-        if (
-            float_compare(
-                float(values.get("taxTotal")),
-                order.amount_tax,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            )
-            != 0
+        if not float_is_zero(
+            float(values.get("taxTotal")) - order.amount_tax,
+            precision_digits=ecommerce_connection_id.precision_digits,
         ):
             errors = self._write_errors(
                 errors,
@@ -1558,13 +1517,9 @@ class EcommerceConnector(models.Model):
             sale_order_line = order.order_line.filtered(
                 lambda a, line=line: a.ecommerce_id == int(line.get("id"))
             )
-            if (
-                float_compare(
-                    float(line.get("total")),
-                    sale_order_line.price_total,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                )
-                != 0
+            if not float_is_zero(
+                float(line.get("total")) - sale_order_line.price_total,
+                precision_digits=ecommerce_connection_id.precision_digits,
             ):
                 errors = self._write_errors(
                     errors,
@@ -1573,13 +1528,9 @@ class EcommerceConnector(models.Model):
                         sale_order_line.price_total, line.get("id"), line.get("total")
                     ),
                 )
-            if (
-                float_compare(
-                    float(line.get("subtotal")),
-                    sale_order_line.price_subtotal,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                )
-                != 0
+            if not float_is_zero(
+                float(line.get("subtotal")) - sale_order_line.price_subtotal,
+                precision_digits=ecommerce_connection_id.precision_digits,
             ):
                 errors = self._write_errors(
                     errors,
@@ -1607,13 +1558,9 @@ class EcommerceConnector(models.Model):
                 shipping_line = order.order_line.filtered(
                     lambda a, line=line: a.ecommerce_shipping_id == int(line.get("id"))
                 )
-                if (
-                    float_compare(
-                        float(line.get("unitPrice")),
-                        shipping_line.price_subtotal,
-                        precision_digits=ecommerce_connection_id.precision_digits,
-                    )
-                    != 0
+                if not float_is_zero(
+                    float(line.get("unitPrice")) - shipping_line.price_subtotal,
+                    precision_digits=ecommerce_connection_id.precision_digits,
                 ):
                     errors = self._write_errors(
                         errors,

--- a/ecommerce_connector/models/ecommerce_connector.py
+++ b/ecommerce_connector/models/ecommerce_connector.py
@@ -1185,6 +1185,36 @@ class EcommerceConnector(models.Model):
             errors = self._check_vat(errors, values)
         return errors
 
+    def _check_currencies_equal(
+        self,
+        errors,
+        value_odoo,
+        value_ecommerce,
+        ecommerce_connection_id,
+        checked_value_name="sales currency",
+        err_extra_info="",
+    ):
+        """Checks that the value_odoo and value_ecommerce are the same
+
+        The configured decimal precision in the ecomercce is used
+        If the values are not equal, a error is returned.
+        """
+        if not float_is_zero(
+            value_odoo - value_ecommerce,
+            precision_digits=ecommerce_connection_id.precision_digits,
+        ):
+            errors = self._write_errors(
+                errors,
+                "Total in {value_name} ({value_odoo}) does not match the value "
+                "sent with the call ({value_ecommerce}) {extra_info}.".format(
+                    value_name=checked_value_name,
+                    value_odoo=value_odoo,
+                    value_ecommerce=value_ecommerce,
+                    extra_info=err_extra_info,
+                ),
+            )
+        return errors
+
     def _check_invoice(self, values, move, errors, ecommerce_connection_id):
         """Returns a string with the errors
 
@@ -1193,48 +1223,32 @@ class EcommerceConnector(models.Model):
         :param move: account.move record with the newly created invoice
         :param errors: string with the current errors
         """
-        if not float_is_zero(
-            float(values.get("total")) - move.amount_total,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Total in sales currency ({}) does not match "
-                "the value sent with the call ({}).".format(
-                    move.amount_total, values.get("total")
-                ),
-            )
-        if not float_is_zero(
-            float(values.get("totalCompany")) - move.amount_total_signed,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Total in company currency ({}) does not match the value sent with "
-                "the call ({}).".format(
-                    move.amount_total_signed, values.get("totalCompany")
-                ),
-            )
-        if not float_is_zero(
-            float(values.get("taxTotal")) - move.amount_tax,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Tax amount in sales currency ({}) does not match the value sent "
-                "with the call ({}).".format(move.amount_tax, values.get("taxTotal")),
-            )
-        if not float_is_zero(
-            float(values.get("taxTotalCompany")) - move.amount_tax_signed,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Tax amount in company currency ({}) does not match the value sent "
-                "with the call ({}).".format(
-                    move.amount_tax_signed, values.get("taxTotalCompany")
-                ),
-            )
+        errors = self._check_currencies_equal(
+            errors,
+            move.amount_total,
+            float(values.get("total")),
+            ecommerce_connection_id,
+        )
+        errors = self._check_currencies_equal(
+            errors,
+            move.amount_total_signed,
+            float(values.get("totalCompany")),
+            ecommerce_connection_id,
+            checked_value_name="company currency",
+        )
+        errors = self._check_currencies_equal(
+            errors,
+            move.amount_tax,
+            float(values.get("taxTotal")),
+            ecommerce_connection_id,
+        )
+        errors = self._check_currencies_equal(
+            errors,
+            move.amount_tax_signed,
+            float(values.get("taxTotalCompany")),
+            ecommerce_connection_id,
+            checked_value_name="company currency",
+        )
         return errors
 
     def _check_invoice_lines(self, values, move, errors, ecommerce_connection_id):
@@ -1257,33 +1271,20 @@ class EcommerceConnector(models.Model):
                     "A unique invoice line with ID {} could not be found."
                     " Found {} lines".format(line.get("id"), len(invoice_line)),
                 )
-            if not error and (
-                not float_is_zero(
-                    float(line.get("total")) - invoice_line.price_total,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                )
-            ):
-                errors = self._write_errors(
+            if not error:
+                errors = self._check_currencies_equal(
                     errors,
-                    "Total in sales currency ({}) in line with ID {} does not match "
-                    "the value sent with the call ({}).".format(
-                        invoice_line.price_total, line.get("id"), line.get("total")
-                    ),
+                    invoice_line.price_total,
+                    float(line.get("total")),
+                    ecommerce_connection_id,
+                    err_extra_info="in line with ID {}".format(line.get("id")),
                 )
-            if not error and (
-                not float_is_zero(
-                    float(line.get("subtotal")) - invoice_line.price_subtotal,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                )
-            ):
-                errors = self._write_errors(
+                errors = self._check_currencies_equal(
                     errors,
-                    "Subtotal in sales currency ({}) in line with ID {} does not "
-                    "match the value sent with the call ({}).".format(
-                        invoice_line.price_subtotal,
-                        line.get("id"),
-                        line.get("subtotal"),
-                    ),
+                    invoice_line.price_subtotal,
+                    float(line.get("subtotal")),
+                    ecommerce_connection_id,
+                    err_extra_info="in line with ID {}".format(line.get("id")),
                 )
         return errors
 
@@ -1309,20 +1310,14 @@ class EcommerceConnector(models.Model):
                 else:
                     compare_val = shipping_line.price_subtotal
                     compare_field = "Subtotal"
-                if not float_is_zero(
-                    float(line.get("unitPrice")) - compare_val,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                ):
-                    errors = self._write_errors(
-                        errors,
-                        "{} in sales currency ({}) in shipping line with ID {} does "
-                        "not match the value sent with the call ({}).".format(
-                            compare_val,
-                            compare_field,
-                            line.get("id"),
-                            line.get("unitPrice"),
-                        ),
-                    )
+                errors = self._check_currencies_equal(
+                    errors,
+                    compare_val,
+                    float(line.get("unitPrice")),
+                    ecommerce_connection_id,
+                    checked_value_name="sales currency {}".format(compare_field),
+                    err_extra_info="in shipping line with ID {}".format(line.get("id")),
+                )
         return errors
 
     def _check_invoice_payments(self, values, move, errors, ecommerce_connection_id):
@@ -1350,17 +1345,15 @@ class EcommerceConnector(models.Model):
                         errors,
                         "Payment with ID %s could not be found." % payment.get("id"),
                     )
-                elif payment_id and not float_is_zero(
-                    float(payment_id.amount_signed) - float(payment.get("unitPrice")),
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                ):
-                    errors = self._write_errors(
+                elif payment_id:
+                    errors = self._check_currencies_equal(
                         errors,
-                        "Amount in invoice currency ({}) for payment with ID {} does"
-                        " not match the value sent with the call ({}).".format(
-                            payment_id.amount_signed,
-                            payment.get("id"),
-                            payment.get("unitPrice"),
+                        payment_id.amount_signed,
+                        float(payment.get("unitPrice")),
+                        ecommerce_connection_id,
+                        checked_value_name="invoice currency {}",
+                        err_extra_info="for payment with ID {}".format(
+                            payment.get("id")
                         ),
                     )
         if errors:
@@ -1456,19 +1449,13 @@ class EcommerceConnector(models.Model):
                 shipping_line = move.invoice_line_ids.filtered(
                     lambda a, line=line: a.ecommerce_shipping_id == int(line.get("id"))
                 )
-                if not float_is_zero(
-                    float(line.get("unitPrice")) - shipping_line.price_subtotal,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                ):
-                    errors = self._write_errors(
-                        errors,
-                        "Subtotal in sales currency ({}) in shipping line with ID "
-                        "{} does not match the value sent with the call ({}).".format(
-                            shipping_line.price_subtotal,
-                            line.get("id"),
-                            line.get("unitPrice"),
-                        ),
-                    )
+                errors = self._check_currencies_equal(
+                    errors,
+                    shipping_line.price_subtotal,
+                    float(line.get("unitPrice")),
+                    ecommerce_connection_id,
+                    err_extra_info="in shipping line with ID {}".format(line.get("id")),
+                )
         return errors
 
     def _check_sale_order(self, values, order, errors, ecommerce_connection_id):
@@ -1479,30 +1466,18 @@ class EcommerceConnector(models.Model):
         :param move: sale.order record with the newly created invoice
         :param errors: string with the current errors
         """
-        if not float_is_zero(
-            float(values.get("total")) - order.amount_total,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Total in sales currency ({}) does not match "
-                "the value sent with the call ({}).".format(
-                    order.amount_total,
-                    values.get("total"),
-                ),
-            )
-        if not float_is_zero(
-            float(values.get("taxTotal")) - order.amount_tax,
-            precision_digits=ecommerce_connection_id.precision_digits,
-        ):
-            errors = self._write_errors(
-                errors,
-                "Tax amount in sales currency ({}) does not match the value sent "
-                "with the call ({}).".format(
-                    order.amount_tax,
-                    values.get("taxTotal"),
-                ),
-            )
+        errors = self._check_currencies_equal(
+            errors,
+            order.amount_total,
+            float(values.get("total")),
+            ecommerce_connection_id,
+        )
+        errors = self._check_currencies_equal(
+            errors,
+            order.amount_tax,
+            float(values.get("taxTotal")),
+            ecommerce_connection_id,
+        )
         return errors
 
     def _check_sale_lines(self, values, order, errors, ecommerce_connection_id):
@@ -1517,30 +1492,20 @@ class EcommerceConnector(models.Model):
             sale_order_line = order.order_line.filtered(
                 lambda a, line=line: a.ecommerce_id == int(line.get("id"))
             )
-            if not float_is_zero(
-                float(line.get("total")) - sale_order_line.price_total,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            ):
-                errors = self._write_errors(
-                    errors,
-                    "Total in sales currency ({}) in line with ID {} does not match"
-                    " the value sent with the call ({}).".format(
-                        sale_order_line.price_total, line.get("id"), line.get("total")
-                    ),
-                )
-            if not float_is_zero(
-                float(line.get("subtotal")) - sale_order_line.price_subtotal,
-                precision_digits=ecommerce_connection_id.precision_digits,
-            ):
-                errors = self._write_errors(
-                    errors,
-                    "Subtotal in sales currency ({}) in line with ID {} does not "
-                    "match the value sent with the call ({}).".format(
-                        sale_order_line.price_subtotal,
-                        line.get("id"),
-                        line.get("subtotal"),
-                    ),
-                )
+            errors = self._check_currencies_equal(
+                errors,
+                sale_order_line.price_total,
+                float(line.get("total")),
+                ecommerce_connection_id,
+                err_extra_info="in line with ID {}".format(line.get("id")),
+            )
+            errors = self._check_currencies_equal(
+                errors,
+                sale_order_line.price_subtotal,
+                float(line.get("subtotal")),
+                ecommerce_connection_id,
+                err_extra_info="in line with ID {}".format(line.get("id")),
+            )
         return errors
 
     def _check_sale_shipping_lines(
@@ -1558,19 +1523,13 @@ class EcommerceConnector(models.Model):
                 shipping_line = order.order_line.filtered(
                     lambda a, line=line: a.ecommerce_shipping_id == int(line.get("id"))
                 )
-                if not float_is_zero(
-                    float(line.get("unitPrice")) - shipping_line.price_subtotal,
-                    precision_digits=ecommerce_connection_id.precision_digits,
-                ):
-                    errors = self._write_errors(
-                        errors,
-                        "Subtotal in sales currency ({}) in shipping line with ID "
-                        "{} does not match the value sent with the call ({}).".format(
-                            shipping_line.price_subtotal,
-                            line.get("id"),
-                            line.get("unitPrice"),
-                        ),
-                    )
+                errors = self._check_currencies_equal(
+                    errors,
+                    shipping_line.price_subtotal,
+                    float(line.get("unitPrice")),
+                    ecommerce_connection_id,
+                    err_extra_info="in shipping line with ID {}".format(line.get("id")),
+                )
         return errors
 
     def _invoice_address_values(self, values):


### PR DESCRIPTION
float_is_zero is the function we have to use because float_compare rounds before comparing the numbers.

Explained in https://github.com/odoo/odoo/blob/3a28e5b0adbb36bdb1155a6854cdfbe4e7f9b187/odoo/tools/float_utils.py#L111-L114